### PR TITLE
Send payment status and method to GAS

### DIFF
--- a/server.js
+++ b/server.js
@@ -40,10 +40,17 @@ app.post('/webhook', express.raw({ type: 'application/json' }), async (req, res)
     console.log("📝 session.metadata:", session.metadata);
 
     try {
+      const payload = {
+        type: event.type,
+        data: { object: session },
+        payment_status: session.payment_status,
+        payment_method: session.payment_method_types?.[0] || ''
+      };
+
       const response = await fetch('https://script.google.com/macros/s/AKfycbx4dsZBMZIaVc1N2ueDxI2jrCvdfXOxbVRvv-3BmMX-x4vUnnF-VXqyPaYT3pTZvUxf/exec', {
         method: 'POST',
         headers: { 'Content-Type': 'application/json' },
-        body: JSON.stringify(event)
+        body: JSON.stringify(payload)
       });
       console.log('✅ GAS response:', await response.text());
     } catch (error) {


### PR DESCRIPTION
## Summary
- Include `payment_status` and first `payment_method` in the webhook payload sent to Google Apps Script

## Testing
- `npm test` *(fails: Missing script "test")*

------
https://chatgpt.com/codex/tasks/task_e_68afaa44d56c833099ac582323f5675f