### PR TITLE
Send payment status and method to GAS

### DIFF
--- a/server.js
+++ b/server.js
@@ -4,6 +4,8 @@ const express = require('express');
 const stripe = require('stripe')(process.env.STRIPE_SECRET_KEY);
 const app = express();
 const PORT = process.env.PORT || 3000;
+const GAS_ENDPOINT =
+  'https://script.google.com/macros/s/AKfycbx4dsZBMZIaVc1N2ueDxI2jrCvdfXOxbVRvv-3BmMX-x4vUnnF-VXqyPaYT3pTZvUxf/exec';
 
 // ✅ CORS 許可ドメイン
 const allowedOrigins = [
@@ -34,16 +36,26 @@ app.post('/webhook', express.raw({ type: 'application/json' }), async (req, res)
     return res.status(400).send(`Webhook Error: ${err.message}`);
   }
 
-  // ✅ 決済完了
-  if (event.type === 'checkout.session.completed') {
+  // ✅ 決済完了・コンビニ決済待ち
+  if (
+    event.type === 'checkout.session.completed' ||
+    event.type === 'checkout.session.async_payment_pending'
+  ) {
     const session = event.data.object;
     console.log("📝 session.metadata:", session.metadata);
 
     try {
-      const response = await fetch('https://script.google.com/macros/s/AKfycbx4dsZBMZIaVc1N2ueDxI2jrCvdfXOxbVRvv-3BmMX-x4vUnnF-VXqyPaYT3pTZvUxf/exec', {
+      const payload = {
+        type: event.type,
+        data: { object: session },
+        payment_status: session.payment_status,
+        payment_method: session.payment_method_types?.[0] || ''
+      };
+
+      const response = await fetch(GAS_ENDPOINT, {
         method: 'POST',
         headers: { 'Content-Type': 'application/json' },
-        body: JSON.stringify(event)
+        body: JSON.stringify(payload)
       });
       console.log('✅ GAS response:', await response.text());
     } catch (error) {
@@ -59,7 +71,7 @@ app.post('/webhook', express.raw({ type: 'application/json' }), async (req, res)
     console.log("🗑 キャンセル処理対象 email:", customerEmail);
 
     try {
-      const cancelResponse = await fetch('https://script.google.com/macros/s/AKfycbx4dsZBMZIaVc1N2ueDxI2jrCvdfXOxbVRvv-3BmMX-x4vUnnF-VXqyPaYT3pTZvUxf/exec', {
+      const cancelResponse = await fetch(GAS_ENDPOINT, {
         method: 'POST',
         headers: { 'Content-Type': 'application/json' },
         body: JSON.stringify({


### PR DESCRIPTION
## Summary
- Forward payment status and first payment method for both `checkout.session.completed` and `checkout.session.async_payment_pending` events to Google Apps Script
- Centralize GAS endpoint constant and include relevant fields in webhook payload

## Testing
- `npm test` *(fails: Missing script "test")*


------
https://chatgpt.com/codex/tasks/task_e_68afaa44d56c833099ac582323f5675f